### PR TITLE
feat: Display Google Map on post pages

### DIFF
--- a/_layouts/post_layout.html
+++ b/_layouts/post_layout.html
@@ -15,6 +15,7 @@
                     <a href="https://github.com/GuilinDev/GuilinDev.github.io/issues" target="_blank">这里给我提 Issues</a>, 谢谢! :)
                 </p>
             </header>
+            {% google_map %}
             {{ content }}
             {% include post_footer.html %}
         </main>


### PR DESCRIPTION
This commit adds a Google Map to the post layout, which will render a map on each post page.

The `jekyll-maps` plugin is used to render the map. The `{% google_map %}` tag is added to the `_layouts/post_layout.html` template.

The map will use the location data from a post's front matter if available, otherwise it will fall back to the global location specified in `_config.yml`.

The Google Maps API key is stored in `_config.yml` to ensure the map functions correctly when deployed to GitHub Pages.